### PR TITLE
list contents of /usr/bin

### DIFF
--- a/system-state-dump.sh
+++ b/system-state-dump.sh
@@ -16,3 +16,9 @@ echo
 echo
 echo "Applications:"
 for app in /usr/share/applications/*.desktop; do app="${app##/*/}"; echo "${app::-8}"; done
+
+
+echo
+echo
+echo "Executables:"
+ls -a /usr/bin


### PR DESCRIPTION
Although `/usr/bin` still does not give a clear picture of all "installed" and executable applications/packages on the system, most packages you compile yourself will appear here. 

Packages that are obtained from outside of the official distribution package manager and/or official user-curated repositories would be of more interest anyways? 